### PR TITLE
remove playwright and storybook setup in workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,14 +24,5 @@ jobs:
       - name: Install dependencies
         run: bun install
 
-      - name: Install playwright
-        run: npx playwright install --with-deps
-
-      - name: Clean storybook dist
-        run: bun run clean
-
-      - name: Build storybook
-        run: bun run build-storybook
-
       - name: Run Test
         run: bun run test


### PR DESCRIPTION
Hiện tại chưa triển khai trên storybook, nên tôi sẽ xoá đi step cài đặt playwright và build storybook trong workflow `test` để giảm thời gian chạy khi tạo PR mới.