### PR TITLE
prevent trigger event khi elements has disabled state

### DIFF
--- a/src/assets/styles/_reset.scss
+++ b/src/assets/styles/_reset.scss
@@ -8,3 +8,8 @@
 body {
   font-family: 'Poppins', serif;
 }
+
+[data-disabled='true'],
+[disabled] {
+  pointer-events: none;
+}

--- a/src/assets/styles/button.scss
+++ b/src/assets/styles/button.scss
@@ -44,7 +44,6 @@
     &[disabled] {
       background-color: $color-disabled;
       border-color: $color-disabled;
-      cursor: not-allowed;
     }
   }
 
@@ -64,7 +63,6 @@
     &[data-disabled='true'],
     &[disabled] {
       color: $color-disabled;
-      cursor: not-allowed;
     }
   }
 
@@ -84,7 +82,6 @@
     &[data-disabled='true'],
     &[disabled] {
       color: $color-disabled;
-      cursor: not-allowed;
     }
   }
 }

--- a/src/assets/styles/checkbox.scss
+++ b/src/assets/styles/checkbox.scss
@@ -42,12 +42,11 @@
     cursor: pointer;
   }
 
-  &:where([data-disabled='true']) {
+  &[data-disabled='true'] {
     .hn-checkbox--wrapper {
       .hn-checkbox--input {
         background-color: $color-disabled;
         border-color: $color-border;
-        cursor: not-allowed;
       }
 
       .hn-checkbox--mark {

--- a/src/assets/styles/field.scss
+++ b/src/assets/styles/field.scss
@@ -49,7 +49,6 @@
   &[data-disabled='true'] {
     .hn-field--wrapper {
       background-color: $color-disabled;
-      cursor: not-allowed;
     }
 
     .hn-field--input {

--- a/src/assets/styles/radio.scss
+++ b/src/assets/styles/radio.scss
@@ -42,11 +42,10 @@
     cursor: pointer;
   }
 
-  &:where([data-disabled='true']) {
+  &[data-disabled='true'] {
     .hn-radio--wrapper {
       .hn-radio--input {
         background-color: $color-disabled;
-        cursor: not-allowed;
 
         &:checked:after {
           background-color: $color-border;

--- a/src/assets/styles/switch.scss
+++ b/src/assets/styles/switch.scss
@@ -7,7 +7,6 @@
   width: fit-content;
   min-width: 51px;
   height: 32px;
-  cursor: pointer;
   background-color: rgba(#17171f, 0.04);
   border-radius: 47px;
   transition: all 0.3s ease;

--- a/src/components/date-picker/date-field.ts
+++ b/src/components/date-picker/date-field.ts
@@ -1,4 +1,6 @@
-export type DateFieldProps = {
+import type { FieldProps } from '../field'
+
+export type DateFieldProps = FieldProps & {
   /** Chỉ ra rằng date-picker có đang focus hay không. */
   focus?: boolean
 }

--- a/src/components/date-picker/date-field.vue
+++ b/src/components/date-picker/date-field.vue
@@ -1,7 +1,7 @@
 <template>
-  <hn-field class="hn-date-field">
+  <hn-field class="hn-date-field" v-bind="fieldProps">
     <div class="hn-field--wrapper hn-date-field--wrapper" :data-focus="focus">
-      <input :value="dateDisplay" class="hn-date--input" readonly />
+      <input :value="dateDisplay" class="hn-field--input hn-date--input" readonly />
       <hn-icon-button :as="IcoCalendar" />
     </div>
   </hn-field>
@@ -10,7 +10,7 @@
 <script setup lang="ts">
 import { IcoCalendar } from '@hn/assets/icons'
 import type { CalendarValue } from '@hn/components/calendar'
-import { HnField } from '@hn/components/field'
+import { getFieldProps, HnField } from '@hn/components/field'
 import { HnIconButton } from '@hn/components/icon-button'
 import dayjs from 'dayjs'
 import { computed } from 'vue'
@@ -18,7 +18,8 @@ import type { DateFieldProps } from './date-field'
 
 defineOptions({ name: 'HnDateField' })
 
-withDefaults(defineProps<DateFieldProps>(), {})
+const props = withDefaults(defineProps<DateFieldProps>(), { size: 'normal' })
+const fieldProps = computed(() => getFieldProps(props))
 
 const modelValue = defineModel<CalendarValue>()
 

--- a/src/components/date-picker/date-picker.ts
+++ b/src/components/date-picker/date-picker.ts
@@ -1,3 +1,4 @@
-import type { CalendarProps } from '@hn/components/calendar'
+import type { CalendarProps } from '../calendar'
+import type { FieldProps } from '../field'
 
-export type DatePickerProps = Pick<CalendarProps, 'minDate' | 'maxDate'>
+export type DatePickerProps = FieldProps & Pick<CalendarProps, 'minDate' | 'maxDate'>

--- a/src/components/date-picker/date-picker.vue
+++ b/src/components/date-picker/date-picker.vue
@@ -1,7 +1,7 @@
 <template>
   <hn-popper v-model="open" class="hn-date-picker" trigger="click">
     <template #anchor>
-      <hn-date-field v-model="modelValue" :focus="open" />
+      <hn-date-field v-model="modelValue" :focus="open" v-bind="fieldProps" />
     </template>
     <template #content>
       <hn-calendar v-model="modelValue" :min-date="minDate" :max-date="maxDate" @change="onClose" />
@@ -12,7 +12,8 @@
 <script setup lang="ts">
 import { type CalendarValue, HnCalendar } from '@hn/components/calendar'
 import { HnPopper } from '@hn/components/popper'
-import { ref } from 'vue'
+import { computed, ref } from 'vue'
+import { getFieldProps } from '../field'
 import HnDateField from './date-field.vue'
 import type { DatePickerProps } from './date-picker'
 
@@ -20,7 +21,8 @@ const modelValue = defineModel<CalendarValue>()
 
 defineOptions({ name: 'HnDatePicker' })
 
-withDefaults(defineProps<DatePickerProps>(), {})
+const props = withDefaults(defineProps<DatePickerProps>(), { size: 'normal' })
+const fieldProps = computed(() => getFieldProps(props))
 
 const open = ref(false)
 

--- a/src/components/date-picker/index.stories.ts
+++ b/src/components/date-picker/index.stories.ts
@@ -3,7 +3,10 @@ import { HnDatePicker } from '.'
 
 const meta: Meta<typeof HnDatePicker> = {
   title: 'HnDatePicker',
-  component: HnDatePicker
+  component: HnDatePicker,
+  args: {
+    size: 'normal'
+  }
 }
 
 export default meta

--- a/src/components/field/index.ts
+++ b/src/components/field/index.ts
@@ -1,2 +1,3 @@
 export type { FieldProps, FieldSize, FieldSlots } from './field'
 export { default as HnField } from './field.vue'
+export { getFieldProps } from './utils'

--- a/src/components/field/utils.ts
+++ b/src/components/field/utils.ts
@@ -1,0 +1,11 @@
+import type { FieldProps } from './field'
+
+export const getFieldProps = <T extends FieldProps>(props: T): FieldProps => {
+  return {
+    label: props.label,
+    size: props.size,
+    hint: props.hint,
+    error: props.error,
+    disabled: props.disabled
+  }
+}


### PR DESCRIPTION
Để ngăn chặn việc trigger event khi click vào các element có custom disable state (`data-disabled="true"`). Tôi đã thêm `pointer-events: none;` vào chúng, và đưa ra file reset để chúng được áp dụng global.