### PR TITLE
refactor(popper): remove unused content element

### DIFF
--- a/src/components/_slot/only-child.ts
+++ b/src/components/_slot/only-child.ts
@@ -6,7 +6,7 @@ export const OnlyChild = defineComponent({
   name: 'HnOnlyChild',
   setup(_, { slots, attrs }) {
     return () => {
-      const forwardRefContext = inject<ForwardRefContext>(FORWARD_REF_KEY)
+      const forwardRefContext = inject<ForwardRefContext | undefined>(FORWARD_REF_KEY, undefined)
       const forwardRefDireactive = useForwardRefDireactive(forwardRefContext?.setForwardRef ?? NOOP)
 
       const defaultSlot = slots.default?.(attrs)

--- a/src/components/popper/popper-anchor.ts
+++ b/src/components/popper/popper-anchor.ts
@@ -1,3 +1,0 @@
-import type { HTMLAttributes } from 'vue'
-
-export type PopperAnchor = {} & /** @vue-ignore */ HTMLAttributes

--- a/src/components/popper/popper-content.vue
+++ b/src/components/popper/popper-content.vue
@@ -9,8 +9,8 @@ import { OnlyChild } from '@hn/components/_slot/only-child'
 import { useForwardRef } from '@hn/composables/useForwardRef'
 import { usePopper } from './usePopper'
 
-defineOptions({ name: 'HnPopperAnchor' })
+defineOptions({ name: 'HnPopperContent' })
 
-const { anchorRef } = usePopper()
-useForwardRef(anchorRef)
+const { contentRef } = usePopper()
+useForwardRef(contentRef)
 </script>

--- a/src/components/popper/popper.ts
+++ b/src/components/popper/popper.ts
@@ -6,6 +6,8 @@ export const POPPER_KEY = Symbol('popper')
 export type PopperContext = {
   /** The anchor element. */
   anchorRef: Ref<HTMLElement | null>
+  /** The content element. */
+  contentRef: Ref<HTMLElement | null>
   /** The arrow element. */
   arrowRef: Ref<HTMLElement | null>
   /** The middleware data. */

--- a/src/components/popper/popper.vue
+++ b/src/components/popper/popper.vue
@@ -12,9 +12,9 @@
     </hn-popper-anchor>
 
     <teleport to="body">
-      <div v-if="open" ref="contentRef" class="hn-popper--content" :style="floatingStyles">
+      <hn-popper-content v-if="open" :style="floatingStyles">
         <slot name="content"></slot>
-      </div>
+      </hn-popper-content>
     </teleport>
   </div>
 </template>
@@ -25,6 +25,7 @@ import { useClickOutside } from '@hn/composables/useClickOutside'
 import { computed, provide, ref } from 'vue'
 import { POPPER_KEY, type PopperContext, type PopperProps, type PopperTrigger } from './popper'
 import HnPopperAnchor from './popper-anchor.vue'
+import HnPopperContent from './popper-content.vue'
 
 defineOptions({ name: 'HnPopper' })
 
@@ -61,6 +62,7 @@ useClickOutside({ refs: [anchorRef, contentRef], callback: onClose })
 
 provide<PopperContext>(POPPER_KEY, {
   anchorRef,
+  contentRef,
   arrowRef,
   middlewareData,
   placement: computed(() => props.placement)


### PR DESCRIPTION
Element `hn-popper--content` hiện tại chỉ có duy nhất chức năng nhận floating position. Tuy nhiên, sau khi sử dụng `hn-only-child` thì `hn-popper--content` không cần thiết nữa nên tôi đã xoá nó.