### PR TITLE
chore(icon): fix `as` prop type warning

### DIFF
--- a/src/components/icon/icon.ts
+++ b/src/components/icon/icon.ts
@@ -1,8 +1,8 @@
-import type { VNode } from 'vue'
+import type { Component } from 'vue'
 
 export type IconProps = {
   /** Chỉ định component được sử dụng trong icon. */
-  as: VNode | string
+  as: string | Component
   /** Nhãn aria cho icon. */
   ariaLabel: string
   /** Chỉ ra rằng icon có ẩn khỏi screen reader hay không. */

--- a/src/components/icon/icon.vue
+++ b/src/components/icon/icon.vue
@@ -1,18 +1,26 @@
 <template>
-  <component :is="as" class="hn-icon" :aria-label="ariaLabel" :aria-hidden="ariaHidden" :role="role"></component>
+  <component
+    :is="computedAs"
+    class="hn-icon"
+    :aria-label="ariaLabel"
+    :aria-hidden="ariaHidden"
+    :role="role"
+  ></component>
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, toRaw } from 'vue'
 import type { IconProps } from './icon'
 
 defineOptions({ name: 'HnIcon' })
 
-// TODO: ở dạng object, `as` đang bị dính warning về reactive
 const props = withDefaults(defineProps<IconProps>(), {
   ariaHidden: true
 })
 
+// NOTE: ở dạng object, `as` đang bị dính warning về reactive
+// Vì vậy, tôi sử dụng `toRaw` để lấy ra giá trị thực tế của `as`
+const computedAs = computed(() => (typeof props.as === 'string' ? props.as : toRaw(props.as)))
 const ariaHidden = computed(() => props.ariaHidden ?? !props.ariaLabel)
 const role = computed(() => props.role || (props.ariaLabel ? 'img' : undefined))
 </script>


### PR DESCRIPTION
Khi truyền prop là một component, Vue sẽ báo warning về reactive. Vì vậy, tôi đã sử dụng `toRaw` để lấy được giá trị gốc của component và fix warning.